### PR TITLE
Improvements

### DIFF
--- a/src/generic/dataInterface.ts
+++ b/src/generic/dataInterface.ts
@@ -48,11 +48,13 @@ import { circlesConfig, Sdk, Avatar } from "@circles-sdk/sdk";
 import { PrivateKeyContractRunner } from "@circles-sdk/adapter-ethers";
 
 // Global config
-const rpcUrl = "https://rpc.gnosischain.com";
+const rpcUrl = process.env.RPC_URL;
 const DemurragedVSInflation = 1;
 const chainId = ChainId.GNOSIS_CHAIN;
 const botPrivateKey = process.env.PRIVATE_KEY!;
-const SELLOFF_PRECISION = BigInt(1e12);
+// @todo share this among two files
+const PROFIT_THRESHOLD = BigInt(1e12); // profit threshold, should be denominated in the colalteral curreny
+
 
 // Constant addresses
 const erc20LiftAddress = "0x5F99a795dD2743C36D63511f0D4bc667e6d3cDB5";
@@ -69,7 +71,14 @@ const wallet = new Wallet(botPrivateKey, provider);
 /**
  * @notice Balancer API instance used to fetch swap paths and quotes.
  */
-const balancerApi = new BalancerApi("https://api-v3.balancer.fi/", chainId);
+const balancerApi = new BalancerApi(
+  "https://api-v3.balancer.fi/",
+  chainId,
+  {
+    clientName: process.env.BALANCER_SDK_CLIENT_NAME,
+    clientVersion: process.env.BALANCER_SDK_CLIENT_VERSION
+  }
+);
 
 /**
  * @notice Circles SDK configuration objects.
@@ -462,21 +471,25 @@ export class DataInterface {
         erc20tokenAddress: tokenAddress! as Address, // we know the tokenAddress must exist, since backing requires wrapping.
         lastUpdated: Date.now(),
       };
-
-      const referencePrice = (await this.getSpotPrice(
-        tokenAddress! as Address,
-      ));
-
-      if(!!referencePrice)
-        nodes.push(node);
+      nodes.push(node);
     }
 
     // we then simply load all basegroups with an ERC20 token (as I currently don't have a simple way to tell which ones have liquidity)
     const baseGroups = await this.getBaseGroups();
     for (const group of baseGroups) {
+      // @todo check if there is such token in the balancer vault
       // const isGroup = await this.checkIsGroup(group as string);
       const tokenAddress = await this.getERC20Token(group.address);
       if (!tokenAddress) continue;
+      // @todo move to const
+      const balancerVaultV2Balance = await this.getERC20Balance(tokenAddress as Address, "0xBA12222222228d8Ba445958a75a0704d566BF2C8");
+      // @todo extend support for v3 in the future
+      if (!balancerVaultV2Balance) {
+        console.log("the group skipped: ", group.address)
+        continue;
+      } else {
+        console.log("group not skipped: ", group.address)
+      }
       const node: CirclesNode = {
         avatar: group.address,
         isGroup: true,
@@ -484,13 +497,7 @@ export class DataInterface {
         mintHandler: group.mintHandler,
         lastUpdated: Date.now(),
       };
-
-      const referencePrice = (await this.getSpotPrice(
-        tokenAddress! as Address,
-      ));
-
-      if(!!referencePrice)
-        nodes.push(node);
+      nodes.push(node);
     }
     if (limit) return nodes.slice(0, limit);
     return nodes;
@@ -629,15 +636,15 @@ export class DataInterface {
    * @return {Promise<bigint>} A promise that resolves to the token balance as a bigint.
    */
   public async getTradingTokenBalance(): Promise<bigint> {
-    return await this.getBotERC20Balance(this.tradingToken.address as Address);
+    return await this.getERC20Balance(this.tradingToken.address as Address, wallet.address as Address);
   }
 
-  public async getBotERC20Balance(tokenAddress: Address): Promise<bigint> {
+  public async getERC20Balance(tokenAddress: Address, holder: Address): Promise<bigint> {
     // Create a contract instance for the token
     const tokenContract = new Contract(tokenAddress, erc20Abi, provider);
 
     // Fetch the balance
-    let balance = await tokenContract.balanceOf(wallet.address);
+    let balance = await tokenContract.balanceOf(holder);
     return balance;
   }
 
@@ -663,7 +670,7 @@ export class DataInterface {
     delayMs: number = 2000,
   ): Promise<bigint> {
     for (let i = 0; i < maxRetries; i++) {
-      const balance = await this.getBotERC20Balance(tokenAddress);
+      const balance = await this.getERC20Balance(tokenAddress, wallet.address as Address);
       if (balance > 0n) {
         return balance;
       }
@@ -812,7 +819,7 @@ export class DataInterface {
     const sorPaths = await balancerApi.sorSwapPaths
       .fetchSorSwapPaths(pathInput)
       .catch(() => {
-        console.error("ERROR: Swap path not found");
+        console.error("ERROR: Swap path not found: ");
       });
 
     // if there is no path, we return null
@@ -827,7 +834,7 @@ export class DataInterface {
         ];
         await this.loggerClient.query(logQuoteInsertQuery, logValues);
       }
-      console.log("No path found");
+      console.log("No swap path found");
       return null;
     }
 
@@ -894,6 +901,7 @@ export class DataInterface {
 
       if (!params.to.isGroup) {
         console.log("Forcing trust for ", params.to.avatar);
+        // @todo rework logic to trust during the sc call
         const trustUpdated = await this.updateMiddlewareTrust(params.to.avatar);
         if (!trustUpdated) {
           console.log("Failed to update middleware trust relationships");
@@ -930,7 +938,7 @@ export class DataInterface {
       return theFlow;
     } catch (error: unknown) {
       if (error instanceof Error) {
-        console.error("Error in flowData generation:", error.message);
+        console.error("Error in flowData generation:", error);
       } else {
         console.error("Error in flowData generation:", error);
       }
@@ -941,7 +949,7 @@ export class DataInterface {
   /**
    * Constructs the input parameters for executeSequentialBatchSwaps function
    * @param {Object} trade - trade data
-   * @param {Object} pathFlowData - The path flow data
+   * @param {Object} demurragedAmount - The amount of demurraged crc
    */
   private async constructExecutionInput(
     trade: Trade,
@@ -978,7 +986,7 @@ export class DataInterface {
       limits: buyQuote.swap.assets.map((asset: Address) => {
         // @todo add profitability to the limit
         if (asset === buyQuote.inputAmount.token.address) {
-          return ((buyQuote.inputAmount.amount * 115n) / 100n).toString();
+          return (buyQuote.inputAmount.amount + PROFIT_THRESHOLD).toString();
         }
         return "0";
       }),
@@ -1066,7 +1074,7 @@ export class DataInterface {
         await this.approveTokens(
           trade.buyQuote.inputAmount.token.address,
           middlewareAddress,
-          buySwapData.limits[0],
+          BigInt(1e18) // Setup extremely huge allowance to avoid redundunt tx
         );
       }
 

--- a/src/generic/dataInterface.ts
+++ b/src/generic/dataInterface.ts
@@ -459,36 +459,34 @@ export class DataInterface {
   // @todo: We need to add groups to this!
   public async loadNodes(limit?: number): Promise<CirclesNode[]> {
     const nodes: CirclesNode[] = [];
-
-    // we first get individual CRCs that are backers
-    const backerAddresses = await this.getCurrentBackers();
-    for (const backerAddress of backerAddresses) {
-      // const isGroup = await this.checkIsGroup(backerAddress as string);
-      const tokenAddress = await this.getERC20Token(backerAddress);
-      const node: CirclesNode = {
-        avatar: backerAddress as Address,
-        isGroup: false,
-        erc20tokenAddress: tokenAddress! as Address, // we know the tokenAddress must exist, since backing requires wrapping.
-        lastUpdated: Date.now(),
-      };
-      nodes.push(node);
+    if(process.env.ONLY_GROUPS !== "true") {
+      // we first get individual CRCs that are backers
+      const backerAddresses = await this.getCurrentBackers();
+      for (const backerAddress of backerAddresses) {
+        // const isGroup = await this.checkIsGroup(backerAddress as string);
+        const tokenAddress = await this.getERC20Token(backerAddress);
+        const node: CirclesNode = {
+          avatar: backerAddress as Address,
+          isGroup: false,
+          erc20tokenAddress: tokenAddress! as Address, // we know the tokenAddress must exist, since backing requires wrapping.
+          lastUpdated: Date.now(),
+        };
+        nodes.push(node);
+      }
     }
 
     // we then simply load all basegroups with an ERC20 token (as I currently don't have a simple way to tell which ones have liquidity)
     const baseGroups = await this.getBaseGroups();
     for (const group of baseGroups) {
-      // @todo check if there is such token in the balancer vault
-      // const isGroup = await this.checkIsGroup(group as string);
       const tokenAddress = await this.getERC20Token(group.address);
       if (!tokenAddress) continue;
-      // @todo move to const
+      // @todo move Balancer Vault to const
+      // Check if there is a group token in the balancerV2 vault
       const balancerVaultV2Balance = await this.getERC20Balance(tokenAddress as Address, "0xBA12222222228d8Ba445958a75a0704d566BF2C8");
       // @todo extend support for v3 in the future
       if (!balancerVaultV2Balance) {
-        console.log("the group skipped: ", group.address)
         continue;
       } else {
-        console.log("group not skipped: ", group.address)
       }
       const node: CirclesNode = {
         avatar: group.address,
@@ -795,6 +793,7 @@ export class DataInterface {
     direction,
     amount,
     logQuote = this.logActivity,
+    skipSwapCallPreparation = false
   }: FetchBalancerQuoteParams): Promise<Swap | null> {
     let swapKind: SwapKind;
     let swapAmount: TokenAmount;
@@ -822,7 +821,7 @@ export class DataInterface {
         console.error("ERROR: Swap path not found: ");
       });
 
-    // if there is no path, we return null
+      // if there is no path, we return null
     if (!sorPaths || sorPaths.length === 0) {
       if (logQuote) {
         const logValues = [
@@ -855,6 +854,8 @@ export class DataInterface {
       ];
       await this.loggerClient.query(logQuoteInsertQuery, logValues);
     }
+
+    if(skipSwapCallPreparation) return swap;
 
     // @dev We attempt to make this call to validate the swap parameters, ensuring we avoid potential errors such as `BAL#305` or other issues related to swap input parameters.
     const result = await swap
@@ -1060,7 +1061,7 @@ export class DataInterface {
         await this.constructExecutionInput(trade, demurragedAmount);
 
       if (!pathFlowData) {
-        console.log("Path is not found");
+        console.log("Liquid path is not found");
         return false;
       }
       // @todo check if `pathFlowData` is not null
@@ -1208,6 +1209,7 @@ export class DataInterface {
       direction: Direction.SELL,
       amount: BigInt(10 ** this.tradingToken.decimals), // Use 1 full unit of trading token as reference
       logQuote: false, // Don't log these routine price checks
+      skipSwapCallPreparation: true
     });
 
     if (!quote) {

--- a/src/generic/dataInterface.ts
+++ b/src/generic/dataInterface.ts
@@ -462,7 +462,13 @@ export class DataInterface {
         erc20tokenAddress: tokenAddress! as Address, // we know the tokenAddress must exist, since backing requires wrapping.
         lastUpdated: Date.now(),
       };
-      nodes.push(node);
+
+      const referencePrice = (await this.getSpotPrice(
+        tokenAddress! as Address,
+      ));
+
+      if(!!referencePrice)
+        nodes.push(node);
     }
 
     // we then simply load all basegroups with an ERC20 token (as I currently don't have a simple way to tell which ones have liquidity)
@@ -478,7 +484,13 @@ export class DataInterface {
         mintHandler: group.mintHandler,
         lastUpdated: Date.now(),
       };
-      nodes.push(node);
+
+      const referencePrice = (await this.getSpotPrice(
+        tokenAddress! as Address,
+      ));
+
+      if(!!referencePrice)
+        nodes.push(node);
     }
     if (limit) return nodes.slice(0, limit);
     return nodes;
@@ -894,7 +906,7 @@ export class DataInterface {
       const buildPath = await this.sdk.v2Pathfinder.getPath(
         maxHolder,
         toAddress,
-        params.requestedAmount,
+        params.requestedAmount.toString(),
         false,
         [params.from.avatar],
         toTokens,

--- a/src/generic/index.ts
+++ b/src/generic/index.ts
@@ -377,10 +377,28 @@ class ArbitrageBot {
       ": ",
       currentTargetPrice,
     );
+
+    this.graph.updateNodeAttributes(edgeInfo.sourceKey, (attr) => {
+      return {
+        ...attr,
+        price: currentSourcePrice,
+        lastUpdated: Date.now(),
+      };
+    });
+
+    this.graph.updateNodeAttributes(edgeInfo.targetKey, (attr) => {
+      return {
+        ...attr,
+        price: currentTargetPrice,
+        lastUpdated: Date.now(),
+      };
+    });
+
     const currentEdgeLiquidity = await this.getCurrentLiquidity(
       edgeInfo.source,
       edgeInfo.target,
     );
+
     console.log(
       "Updated liquidity between:",
       edgeInfo.source.avatar,
@@ -395,22 +413,6 @@ class ArbitrageBot {
       return {
         ...attr,
         liquidity: currentEdgeLiquidity,
-        lastUpdated: Date.now(),
-      };
-    });
-
-    this.graph.updateNodeAttributes(edgeInfo.sourceKey, (attr) => {
-      return {
-        ...attr,
-        price: currentSourcePrice,
-        lastUpdated: Date.now(),
-      };
-    });
-
-    this.graph.updateNodeAttributes(edgeInfo.targetKey, (attr) => {
-      return {
-        ...attr,
-        price: currentTargetPrice,
         lastUpdated: Date.now(),
       };
     });

--- a/src/generic/index.ts
+++ b/src/generic/index.ts
@@ -224,7 +224,7 @@ class ArbitrageBot {
     const edgeInfo = this.getEdgeInfo(edgeKey);
 
     // the logic is an estimate of the maximal profit:
-    // It's the price delta^2 times the liquidity
+    // It's the price delta times the liquidity
     const sourcePrice = edgeInfo.source.price;
     const targetPrice = edgeInfo.target.price;
     const liquidity = edgeInfo.edge.liquidity;
@@ -236,7 +236,7 @@ class ArbitrageBot {
       return 0n;
     }
     const delta = targetPrice - sourcePrice;
-    return delta <= 0 ? 0n : delta * delta * liquidity;
+    return delta <= 0 ? 0n : delta * liquidity;
   }
 
   private calculateNorm(scores: bigint[]): bigint {
@@ -517,6 +517,11 @@ class ArbitrageBot {
         // Breaking out of the loop since we found working quotes
         break;
       }
+    }
+
+    if(liquidity < currentAmount) {
+      console.log("No liquid path available");
+      return null;
     }
 
     if(!bestTrade!.profit) return null;

--- a/src/generic/index.ts
+++ b/src/generic/index.ts
@@ -14,6 +14,7 @@ import {
 
 // global variables
 const LOG_ACTIVITY = true;
+// @todo make this amount adjustable
 const QUERY_REFERENCE_AMOUNT = BigInt(1e17);
 const EXPLORATION_RATE = 0.1;
 const MIN_BUYING_AMOUNT = QUERY_REFERENCE_AMOUNT;
@@ -223,7 +224,7 @@ class ArbitrageBot {
     const edgeInfo = this.getEdgeInfo(edgeKey);
 
     // the logic is an estimate of the maximal profit:
-    // It's the price delta times the liquidity
+    // It's the price delta^2 times the liquidity
     const sourcePrice = edgeInfo.source.price;
     const targetPrice = edgeInfo.target.price;
     const liquidity = edgeInfo.edge.liquidity;
@@ -235,15 +236,15 @@ class ArbitrageBot {
       return 0n;
     }
     const delta = targetPrice - sourcePrice;
-    return delta <= 0 ? 0n : delta * liquidity;
+    return delta <= 0 ? 0n : delta * delta * liquidity;
   }
 
   private calculateNorm(scores: bigint[]): bigint {
-    // Add small constant to each score and compute sum of squares
+    // Add small constant to each score and compute sum
     const EPSILON = 1000000n; // Small constant to avoid zero vector
     return scores.reduce((sum, score) => {
       const adjustedScore = score + EPSILON;
-      return sum + adjustedScore * adjustedScore;
+      return sum + adjustedScore;
     }, 0n);
   }
 
@@ -267,12 +268,12 @@ class ArbitrageBot {
       return edges[Math.floor(Math.random() * edges.length)];
     }
 
-    // Calculate probabilities proportional to squared scores
+    // Calculate probabilities proportional to scores
     const EPSILON = 1000000n;
     const probabilities = scores.map((score) => {
       const adjustedScore = score + EPSILON;
       return (
-        Number((adjustedScore * adjustedScore * 1000000n) / norm) / 1000000
+        Number((adjustedScore * 1000000n) / norm) / 1000000
       );
     });
 
@@ -452,7 +453,7 @@ class ArbitrageBot {
   private async getCurrentSpotPrice(node: CirclesNode): Promise<bigint | null> {
     const swapData = await this.dataInterface.getSpotPrice(
       node.erc20tokenAddress,
-    );
+    );    
     if (!swapData) {
       return null;
     }
@@ -471,44 +472,56 @@ class ArbitrageBot {
     target: CirclesNode,
     liquidity: bigint,
   ): Promise<Trade | null> {
-    // @todo rework to have buy collateral at slightly lover value
-    let currentAmount = MIN_BUYING_AMOUNT;
-
+    // @todo improve types
+    const referenceAmounts = [MIN_BUYING_AMOUNT, MIN_BUYING_AMOUNT * 10n];
     let collateralBalance = await this.dataInterface.getTradingTokenBalance();
+    let currentAmount = 0n;
+    let bestTrade: Trade;
 
-    // Get initial quotes
-    const initialBuyQuote = await this.dataInterface.getTradingQuote({
-      tokenAddress: source.erc20tokenAddress,
-      direction: Direction.BUY,
-      amount: currentAmount,
-    });
+    // Try different reference amounts until we find one that works
+    for (currentAmount of referenceAmounts) {
+      console.log(`Trying reference amount: ${currentAmount}`);
+      
+      // Get quotes for current amount
+      const initialBuyQuote = await this.dataInterface.getTradingQuote({
+        tokenAddress: source.erc20tokenAddress,
+        direction: Direction.BUY,
+        amount: currentAmount,
+      });
 
-    const initialSellQuote = await this.dataInterface.getTradingQuote({
-      tokenAddress: target.erc20tokenAddress,
-      direction: Direction.SELL,
-      amount: (currentAmount * 999n) / 1000n,
-    });
+      const initialSellQuote = await this.dataInterface.getTradingQuote({
+        tokenAddress: target.erc20tokenAddress,
+        direction: Direction.SELL,
+        amount: (currentAmount * 999n) / 1000n,
+      });
 
-    if (
-      !initialBuyQuote ||
-      !initialSellQuote ||
-      initialBuyQuote.inputAmount.amount > collateralBalance
-    ) {
-      return null;
+      // Check if both quotes are valid and we have enough balance
+      if (
+        initialBuyQuote &&
+        initialSellQuote &&
+        initialBuyQuote.inputAmount.amount <= collateralBalance
+      ) {
+        console.log(`Successfully got quotes with reference amount: ${currentAmount}`);
+
+        bestTrade = {
+          buyQuote: initialBuyQuote,
+          sellQuote: initialSellQuote,
+          buyNode: source,
+          sellNode: target,
+          amount: currentAmount,
+          profit:
+            initialSellQuote.outputAmount.amount -
+            initialBuyQuote.inputAmount.amount,
+        };
+                
+        // Breaking out of the loop since we found working quotes
+        break;
+      }
     }
 
-    let bestTrade: Trade = {
-      buyQuote: initialBuyQuote,
-      sellQuote: initialSellQuote,
-      buyNode: source,
-      sellNode: target,
-      amount: currentAmount,
-      profit:
-        initialSellQuote.outputAmount.amount -
-        initialBuyQuote.inputAmount.amount,
-    };
+    if(!bestTrade!.profit) return null;
 
-    // @todo: This needs to be improved as right now it simply reverts wheneever it doesn't get a good quote (e.g. because of missing liquidity in the pools...)
+    // @todo This needs to be improved as right now it simply reverts whenever it doesn't get a good quote (e.g. because of missing liquidity in the pools...)
     while (currentAmount < liquidity / 2n) {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
@@ -528,7 +541,7 @@ class ArbitrageBot {
       });
 
       if (!buyQuote || !sellQuote) {
-        return bestTrade;
+        return bestTrade!;
       }
 
       const currentProfit =
@@ -536,10 +549,10 @@ class ArbitrageBot {
 
       // If profit decreased or the new quote exceeds the bot's balance in collateral, return the previous (best) trade
       if (
-        currentProfit < bestTrade.profit ||
+        currentProfit < bestTrade!.profit ||
         buyQuote.inputAmount.amount > collateralBalance
       ) {
-        return bestTrade;
+        return bestTrade!;
       }
 
       // Update best trade if profit increased
@@ -553,7 +566,7 @@ class ArbitrageBot {
       };
     }
 
-    return bestTrade;
+    return bestTrade!;
   }
 
   async executeTrade(trade: Trade): Promise<boolean> {

--- a/src/generic/interfaces/index.ts
+++ b/src/generic/interfaces/index.ts
@@ -47,6 +47,7 @@ export interface FetchBalancerQuoteParams {
   direction: Direction;
   amount: bigint;
   logQuote?: boolean;
+  skipSwapCallPreparation?: boolean;
 }
 
 export interface BalanceRow {


### PR DESCRIPTION
New env variables:
`BALANCER_SDK_CLIENT_NAME` - header with the name of the app for the balancer api calls
`BALANCER_SDK_CLIENT_VERSION` - header with the version of the app for the balancer api calls
`ONLY_GROUPS` - toggle which allows to only arbitrate the prices for the groups when the `"true"` value is set

Updates:
- improved price quotation, if there is no value returned to the reference amount `1e17` it tries `1e18`
- added headers during the balancer api calls
- ability to turn only groups mode
- filtering out groups which are not traded on balancer
- reduce amount of approve tx
- smoothen the probability distribution of the edge picking algorithm